### PR TITLE
Disallow '0' as claim topic

### DIFF
--- a/contracts/registry/implementation/ClaimTopicsRegistry.sol
+++ b/contracts/registry/implementation/ClaimTopicsRegistry.sol
@@ -76,6 +76,7 @@ contract ClaimTopicsRegistry is IClaimTopicsRegistry, OwnableUpgradeable, CTRSto
      *  @dev See {IClaimTopicsRegistry-addClaimTopic}.
      */
     function addClaimTopic(uint256 _claimTopic) external override onlyOwner {
+        require(_claimTopic != 0, "claim topic cannot be 0");
         uint256 length = _claimTopics.length;
         require(length < 15, "cannot require more than 15 topics");
         for (uint256 i = 0; i < length; i++) {

--- a/test/registries/claim-topics-registry.test.ts
+++ b/test/registries/claim-topics-registry.test.ts
@@ -28,6 +28,17 @@ describe('ClaimTopicsRegistry', () => {
     });
 
     describe('when sender is owner', () => {
+      describe('when claim topic is zero', () => {
+        it('should revert', async () => {
+          const {
+            suite: { claimTopicsRegistry },
+            accounts: { deployer },
+          } = await loadFixture(deployFullSuiteFixture);
+
+          await expect(claimTopicsRegistry.connect(deployer).addClaimTopic(0)).to.be.revertedWith('claim topic cannot be 0');
+        });
+      });
+
       describe('when topic array contains more than 14 elements', () => {
         it('should revert', async () => {
           const {
@@ -35,7 +46,7 @@ describe('ClaimTopicsRegistry', () => {
             accounts: { deployer },
           } = await loadFixture(deployFullSuiteFixture);
 
-          await Promise.all(Array.from({ length: 14 }, (_, i) => i).map((i) => claimTopicsRegistry.addClaimTopic(i)));
+          await Promise.all(Array.from({ length: 14 }, (_, i) => i).map((i) => claimTopicsRegistry.addClaimTopic(i+1)));
 
           await expect(claimTopicsRegistry.connect(deployer).addClaimTopic(14)).to.be.revertedWith('cannot require more than 15 topics');
         });


### PR DESCRIPTION
This PR handles an edge case where '0' is used as a claim topic. 

Regardless of if it makes sense to use '0' as a claim topic, the `ClaimTopicsRegistry` contract allows '0' to be added as a required claim topic. If this is done, the identity registry [will not correctly detect that a claim topic is not present](https://github.com/ERC-3643/ERC-3643/blob/main/contracts/registry/implementation/IdentityRegistry.sol#L200), and will attempt to proceed by checking the claim's issuer (zero address) with an external call to the `isClaimValid` function. This call causes an unhandled revert.

Steps to reproduce edge case:
- Add '0' as a claim topic to the required claims registry.
- Add some other claims to the required claims registry.
- Run `isVerified` on any identity contract and note the unhandled revert.
