### PR TITLE
:recycle: refactor Gateway

### DIFF
--- a/.github/workflows/push_checking.yml
+++ b/.github/workflows/push_checking.yml
@@ -52,3 +52,14 @@ jobs:
           path: |
             coverage/
             coverage.json
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: [lint, unit_test]
+    if: always()
+    steps:
+      - name: Verify upstream jobs succeeded
+        run: |
+          echo "lint: ${{ needs.lint.result }}"
+          echo "unit_test: ${{ needs.unit_test.result }}"
+          test "${{ needs.lint.result }}" = "success" -a "${{ needs.unit_test.result }}" = "success"

--- a/contracts/factory/ITREXGateway.sol
+++ b/contracts/factory/ITREXGateway.sol
@@ -102,6 +102,22 @@ interface ITREXGateway {
     /// event emitted whenever a TREX token has been deployed by the TREX factory through the use of the Gateway
     event GatewaySuiteDeploymentProcessed(address indexed requester, address intendedOwner, uint256 feeApplied);
 
+    /// event emitted when an Identity Registry Storage is registered on the Gateway with its owner
+    /// (automatically at deployment of a new IRS, or manually by an admin for pre-existing IRS)
+    event IRSRegistered(address indexed irs, address indexed irsOwner);
+
+    /// event emitted when the registered owner of an IRS is changed
+    event IRSOwnershipTransferred(address indexed irs, address indexed previousOwner, address indexed newOwner);
+
+    /// event emitted when the owner of an IRS allows another token owner to bind new Identity Registries to it
+    event IRSUsageAuthorized(address indexed irs, address indexed tokenOwner);
+
+    /// event emitted when the owner of an IRS revokes the right of a token owner to bind new Identity Registries to it
+    event IRSUsageRevoked(address indexed irs, address indexed tokenOwner);
+
+    /// event emitted when the contract ownership of an IRS is recovered from the Factory by the registered IRS owner
+    event IRSOwnershipRecovered(address indexed irs, address indexed newOwner);
+
     /// Functions
 
     /**
@@ -268,6 +284,87 @@ interface ITREXGateway {
     function batchDeployTREXSuite(
         ITREXFactory.TokenDetails[] memory _tokenDetails,
         ITREXFactory.ClaimDetails[] memory _claimDetails) external;
+
+    /**
+    * @notice Registers a pre-existing Identity Registry Storage on the Gateway and sets its owner.
+    * @dev Only an admin (owner or agent of the Gateway) can call this method.
+    * Used to onboard IRS contracts deployed before this version of the Gateway (or outside of it) so that
+    * they can be reused in new deployments under the same access rules as IRS deployed through the Gateway.
+    * The IRS must be owned by the Factory, otherwise the Factory cannot bind new Identity Registries to it.
+    * Reverts with `IRSAlreadyRegistered` if the IRS is already registered.
+    * Reverts with `IRSNotOwnedByFactory` if the Factory is not the owner of the IRS.
+    * @param irs The address of the Identity Registry Storage.
+    * @param irsOwner The address to register as owner of the IRS (typically the owner of the token(s) using it).
+    * emits IRSRegistered
+    */
+    function registerIRS(address irs, address irsOwner) external;
+
+    /**
+    * @notice Transfers the registered ownership of an IRS on the Gateway to a new address.
+    * @dev Only the registered owner of the IRS can call this method.
+    * This does not change the on-chain `Ownable` owner of the IRS contract (which stays the Factory),
+    * it only changes who controls the IRS sharing rules on the Gateway.
+    * Reverts with `ZeroAddress` if `newOwner` is the zero address.
+    * Reverts with `OnlyIRSOwnerCall` if the caller is not the registered owner of the IRS.
+    * @param irs The address of the Identity Registry Storage.
+    * @param newOwner The address of the new registered owner.
+    * emits IRSOwnershipTransferred
+    */
+    function transferIRSOwnership(address irs, address newOwner) external;
+
+    /**
+    * @notice Allows another token owner to reuse the IRS in new TREX suite deployments.
+    * @dev Only the registered owner of the IRS can call this method.
+    * Once authorized, `tokenOwner` can be set as `TokenDetails.owner` in a deployment referencing this IRS,
+    * which results in the new Identity Registry being bound to the IRS (and thus becoming an agent of it).
+    * Reverts with `OnlyIRSOwnerCall` if the caller is not the registered owner of the IRS.
+    * Reverts with `IRSUsageAlreadyAuthorized` if `tokenOwner` is already authorized.
+    * @param irs The address of the Identity Registry Storage.
+    * @param tokenOwner The address of the token owner allowed to reuse the IRS.
+    * emits IRSUsageAuthorized
+    */
+    function authorizeIRSUsage(address irs, address tokenOwner) external;
+
+    /**
+    * @notice Revokes the right of a token owner to reuse the IRS in new TREX suite deployments.
+    * @dev Only the registered owner of the IRS can call this method.
+    * This only blocks future deployments; Identity Registries already bound to the IRS are not unbound
+    * (the IRS owner can do that directly on the IRS after recovering its ownership).
+    * Reverts with `OnlyIRSOwnerCall` if the caller is not the registered owner of the IRS.
+    * Reverts with `IRSUsageNotAuthorized` if `tokenOwner` is not currently authorized.
+    * @param irs The address of the Identity Registry Storage.
+    * @param tokenOwner The address of the token owner losing the right to reuse the IRS.
+    * emits IRSUsageRevoked
+    */
+    function revokeIRSUsage(address irs, address tokenOwner) external;
+
+    /**
+    * @notice Recovers the contract ownership of an IRS from the Factory.
+    * @dev Only the registered owner of the IRS can call this method.
+    * Calls `recoverContractOwnership` on the Factory, transferring the `Ownable` ownership of the IRS to the caller.
+    * After this call the Factory can no longer bind new Identity Registries to this IRS, so any deployment
+    * referencing it will revert with `IRSNotOwnedByFactory` until ownership is given back to the Factory.
+    * Reverts with `OnlyIRSOwnerCall` if the caller is not the registered owner of the IRS.
+    * @param irs The address of the Identity Registry Storage.
+    * emits IRSOwnershipRecovered
+    */
+    function recoverIRSOwnership(address irs) external;
+
+    /**
+    * @notice Returns the registered owner of an IRS.
+    * @param irs The address of the Identity Registry Storage.
+    * @return The registered owner, or the zero address if the IRS is not registered on the Gateway.
+    */
+    function getIRSOwner(address irs) external view returns(address);
+
+    /**
+    * @notice Checks whether a token owner is allowed to reuse an IRS in new deployments.
+    * @dev Returns true if `tokenOwner` is the registered owner of the IRS or has been authorized by them.
+    * @param irs The address of the Identity Registry Storage.
+    * @param tokenOwner The address of the token owner.
+    * @return True if `tokenOwner` can reference `irs` in `TokenDetails.irs`, false otherwise.
+    */
+    function isIRSUsageAuthorized(address irs, address tokenOwner) external view returns(bool);
 
     /**
     * @notice Retrieves the current public deployment status.

--- a/contracts/factory/TREXGateway.sol
+++ b/contracts/factory/TREXGateway.sol
@@ -487,7 +487,7 @@ contract TREXGateway is ITREXGateway, AgentRole {
      *  @dev See {ITREXGateway-isIRSUsageAuthorized}.
      */
     function isIRSUsageAuthorized(address irs, address tokenOwner) public override view returns(bool) {
-        return _irsOwner[irs] == tokenOwner || _irsAuthorizedUsers[irs][tokenOwner];
+        return (_irsOwner[irs] != address(0)) && (_irsOwner[irs] == tokenOwner || _irsAuthorizedUsers[irs][tokenOwner]);
     }
 
     /// registers the IRS deployed by the factory for `_salt` with `irsOwner` as its owner

--- a/contracts/factory/TREXGateway.sol
+++ b/contracts/factory/TREXGateway.sol
@@ -63,6 +63,7 @@ pragma solidity 0.8.17;
 
 import "./ITREXGateway.sol";
 import "../roles/AgentRole.sol";
+import "../token/IToken.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -102,6 +103,24 @@ error OnlyAdminCall();
 /// Batch Size is too big, could run out of gas
 error BatchMaxLengthExceeded(uint16 lengthLimit);
 
+/// The IRS is not registered on the Gateway, it cannot be reused in a deployment
+error IRSNotRegistered(address irs);
+
+/// The IRS is already registered on the Gateway
+error IRSAlreadyRegistered(address irs);
+
+/// The Factory is not the owner of the IRS, it cannot bind new Identity Registries to it
+error IRSNotOwnedByFactory(address irs);
+
+/// Only the registered owner of the IRS can call
+error OnlyIRSOwnerCall(address irs);
+
+/// The token owner is not allowed to reuse this IRS
+error IRSUsageNotAuthorized(address irs, address tokenOwner);
+
+/// The token owner is already allowed to reuse this IRS
+error IRSUsageAlreadyAuthorized(address irs, address tokenOwner);
+
 
 contract TREXGateway is ITREXGateway, AgentRole {
 
@@ -122,6 +141,12 @@ contract TREXGateway is ITREXGateway, AgentRole {
 
     /// mapping for deployment discounts on fees
     mapping(address => uint16) private _feeDiscount;
+
+    /// mapping IRS address => registered owner of the IRS (controls reuse of the IRS in new deployments)
+    mapping(address => address) private _irsOwner;
+
+    /// mapping IRS address => token owner => allowed to reuse the IRS in new deployments
+    mapping(address => mapping(address => bool)) private _irsAuthorizedUsers;
 
     /// constructor of the contract, setting up the factory address and
     /// the public deployment status
@@ -291,6 +316,75 @@ contract TREXGateway is ITREXGateway, AgentRole {
     }
 
     /**
+     *  @dev See {ITREXGateway-registerIRS}.
+     */
+    function registerIRS(address irs, address irsOwner) external override {
+        if(!isAgent(msg.sender) && msg.sender != owner()) {
+            revert OnlyAdminCall();
+        }
+        if(irs == address(0) || irsOwner == address(0)) {
+            revert ZeroAddress();
+        }
+        if(_irsOwner[irs] != address(0)) {
+            revert IRSAlreadyRegistered(irs);
+        }
+        if(Ownable(irs).owner() != _factory) {
+            revert IRSNotOwnedByFactory(irs);
+        }
+        _irsOwner[irs] = irsOwner;
+        emit IRSRegistered(irs, irsOwner);
+    }
+
+    /**
+     *  @dev See {ITREXGateway-transferIRSOwnership}.
+     */
+    function transferIRSOwnership(address irs, address newOwner) external override {
+        _onlyIRSOwner(irs);
+        if(newOwner == address(0)) {
+            revert ZeroAddress();
+        }
+        address previousOwner = _irsOwner[irs];
+        _irsOwner[irs] = newOwner;
+        emit IRSOwnershipTransferred(irs, previousOwner, newOwner);
+    }
+
+    /**
+     *  @dev See {ITREXGateway-authorizeIRSUsage}.
+     */
+    function authorizeIRSUsage(address irs, address tokenOwner) external override {
+        _onlyIRSOwner(irs);
+        if(tokenOwner == address(0)) {
+            revert ZeroAddress();
+        }
+        if(_irsAuthorizedUsers[irs][tokenOwner]) {
+            revert IRSUsageAlreadyAuthorized(irs, tokenOwner);
+        }
+        _irsAuthorizedUsers[irs][tokenOwner] = true;
+        emit IRSUsageAuthorized(irs, tokenOwner);
+    }
+
+    /**
+     *  @dev See {ITREXGateway-revokeIRSUsage}.
+     */
+    function revokeIRSUsage(address irs, address tokenOwner) external override {
+        _onlyIRSOwner(irs);
+        if(!_irsAuthorizedUsers[irs][tokenOwner]) {
+            revert IRSUsageNotAuthorized(irs, tokenOwner);
+        }
+        delete _irsAuthorizedUsers[irs][tokenOwner];
+        emit IRSUsageRevoked(irs, tokenOwner);
+    }
+
+    /**
+     *  @dev See {ITREXGateway-recoverIRSOwnership}.
+     */
+    function recoverIRSOwnership(address irs) external override {
+        _onlyIRSOwner(irs);
+        ITREXFactory(_factory).recoverContractOwnership(irs, msg.sender);
+        emit IRSOwnershipRecovered(irs, msg.sender);
+    }
+
+    /**
      *  @dev See {ITREXGateway-batchDeployTREXSuite}.
      */
     function batchDeployTREXSuite(
@@ -334,6 +428,13 @@ contract TREXGateway is ITREXGateway, AgentRole {
     }
 
     /**
+     *  @dev See {ITREXGateway-getIRSOwner}.
+     */
+    function getIRSOwner(address irs) external override view returns(address) {
+        return _irsOwner[irs];
+    }
+
+    /**
      *  @dev See {ITREXGateway-deployTREXSuite}.
      */
     function deployTREXSuite(ITREXFactory.TokenDetails memory _tokenDetails, ITREXFactory.ClaimDetails memory _claimDetails)
@@ -343,6 +444,10 @@ contract TREXGateway is ITREXGateway, AgentRole {
         }
         if(_publicDeploymentStatus == true && msg.sender != _tokenDetails.owner && !isDeployer(msg.sender)) {
             revert PublicCannotDeployOnBehalf();
+        }
+        // an existing IRS can only be reused by its registered owner or by a token owner they authorized
+        if(_tokenDetails.irs != address(0)) {
+            _checkIRSUsage(_tokenDetails.irs, _tokenDetails.owner);
         }
         uint256 feeApplied = 0;
         if(_deploymentFeeEnabled == true) {
@@ -357,6 +462,10 @@ contract TREXGateway is ITREXGateway, AgentRole {
         }
         string memory _salt  = string(abi.encodePacked(Strings.toHexString(_tokenDetails.owner), _tokenDetails.name));
         ITREXFactory(_factory).deployTREXSuite(_salt, _tokenDetails, _claimDetails);
+        // a freshly deployed IRS is registered with the token owner as its owner
+        if(_tokenDetails.irs == address(0)) {
+            _registerDeployedIRS(_salt, _tokenDetails.owner);
+        }
         emit GatewaySuiteDeploymentProcessed(msg.sender, _tokenDetails.owner, feeApplied);
     }
 
@@ -372,5 +481,41 @@ contract TREXGateway is ITREXGateway, AgentRole {
      */
     function calculateFee(address deployer) public override view returns(uint256) {
         return _deploymentFee.fee - ((_feeDiscount[deployer] * _deploymentFee.fee) / 10000);
+    }
+
+    /**
+     *  @dev See {ITREXGateway-isIRSUsageAuthorized}.
+     */
+    function isIRSUsageAuthorized(address irs, address tokenOwner) public override view returns(bool) {
+        return _irsOwner[irs] == tokenOwner || _irsAuthorizedUsers[irs][tokenOwner];
+    }
+
+    /// registers the IRS deployed by the factory for `_salt` with `irsOwner` as its owner
+    function _registerDeployedIRS(string memory _salt, address irsOwner) private {
+        address token = ITREXFactory(_factory).getToken(_salt);
+        address irs = address(IToken(token).identityRegistry().identityStorage());
+        _irsOwner[irs] = irsOwner;
+        emit IRSRegistered(irs, irsOwner);
+    }
+
+    /// reverts if `tokenOwner` is not allowed to bind a new Identity Registry to `irs`
+    /// or if the factory is not in a position to do the binding
+    function _checkIRSUsage(address irs, address tokenOwner) private view {
+        if(_irsOwner[irs] == address(0)) {
+            revert IRSNotRegistered(irs);
+        }
+        if(!isIRSUsageAuthorized(irs, tokenOwner)) {
+            revert IRSUsageNotAuthorized(irs, tokenOwner);
+        }
+        if(Ownable(irs).owner() != _factory) {
+            revert IRSNotOwnedByFactory(irs);
+        }
+    }
+
+    /// reverts if msg.sender is not the registered owner of the IRS
+    function _onlyIRSOwner(address irs) private view {
+        if(_irsOwner[irs] == address(0) || msg.sender != _irsOwner[irs]) {
+            revert OnlyIRSOwnerCall(irs);
+        }
     }
 }

--- a/test/gateway-irs.test.ts
+++ b/test/gateway-irs.test.ts
@@ -27,7 +27,9 @@ async function setup() {
   return { context, gateway };
 }
 
-async function irsOfLastDeployment(context: any, owner: string, name: string) {
+type FullSuiteContext = Awaited<ReturnType<typeof deployFullSuiteFixture>>;
+
+async function irsOfLastDeployment(context: FullSuiteContext, owner: string, name: string) {
   const salt = owner.toLowerCase() + name;
   const tokenAddr = await context.factories.trexFactory.getToken(salt);
   const token = await ethers.getContractAt('Token', tokenAddr);
@@ -135,7 +137,10 @@ describe('TREXGateway - IRS access control', () => {
       const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
 
       await expect(gateway.connect(bob).transferIRSOwnership(irs, bob.address)).to.be.revertedWithCustomError(gateway, 'OnlyIRSOwnerCall');
-      await expect(gateway.connect(alice).transferIRSOwnership(irs, ethers.constants.AddressZero)).to.be.revertedWithCustomError(gateway, 'ZeroAddress');
+      await expect(gateway.connect(alice).transferIRSOwnership(irs, ethers.constants.AddressZero)).to.be.revertedWithCustomError(
+        gateway,
+        'ZeroAddress',
+      );
       await expect(gateway.connect(alice).transferIRSOwnership(irs, bob.address))
         .to.emit(gateway, 'IRSOwnershipTransferred')
         .withArgs(irs, alice.address, bob.address);

--- a/test/gateway-irs.test.ts
+++ b/test/gateway-irs.test.ts
@@ -194,4 +194,45 @@ describe('TREXGateway - IRS access control', () => {
       expect(await irsOfLastDeployment(context, bob.address, 'BobToken')).to.equal(legacyIrs.address);
     });
   });
+
+  describe('isIRSUsageAuthorized', () => {
+    it('returns false for an unregistered IRS, whoever the token owner is', async () => {
+      const { context, gateway } = await setup();
+      const alice = context.accounts.aliceWallet;
+      // never went through registerIRS nor a gateway deployment, so its owner slot is still empty
+      const unregisteredIrs = context.suite.identityRegistryStorage.address;
+
+      expect(await gateway.getIRSOwner(unregisteredIrs)).to.equal(ethers.constants.AddressZero);
+      expect(await gateway.isIRSUsageAuthorized(unregisteredIrs, alice.address)).to.be.false;
+      // the zero address must not be reported as authorized just because the owner slot is empty:
+      // this is what the `_irsOwner[irs] != address(0)` guard prevents
+      expect(await gateway.isIRSUsageAuthorized(unregisteredIrs, ethers.constants.AddressZero)).to.be.false;
+      expect(await gateway.isIRSUsageAuthorized(ethers.Wallet.createRandom().address, ethers.constants.AddressZero)).to.be.false;
+      expect(await gateway.isIRSUsageAuthorized(ethers.constants.AddressZero, ethers.constants.AddressZero)).to.be.false;
+    });
+
+    it('keeps returning false for the zero address once the IRS is registered', async () => {
+      const { context, gateway } = await setup();
+      const alice = context.accounts.aliceWallet;
+      await gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken'), emptyClaims);
+      const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
+
+      expect(await gateway.isIRSUsageAuthorized(irs, alice.address)).to.be.true;
+      // registered now, but the zero address is neither the owner nor an authorized user
+      expect(await gateway.isIRSUsageAuthorized(irs, ethers.constants.AddressZero)).to.be.false;
+    });
+
+    it('goes back to false for the zero address after the IRS owner recovers Ownable ownership', async () => {
+      const { context, gateway } = await setup();
+      const alice = context.accounts.aliceWallet;
+      await gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken'), emptyClaims);
+      const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
+
+      // recovering does not clear the registration, so the guard still holds
+      await gateway.connect(alice).recoverIRSOwnership(irs);
+      expect(await gateway.getIRSOwner(irs)).to.equal(alice.address);
+      expect(await gateway.isIRSUsageAuthorized(irs, ethers.constants.AddressZero)).to.be.false;
+      expect(await gateway.isIRSUsageAuthorized(irs, alice.address)).to.be.true;
+    });
+  });
 });

--- a/test/gateway-irs.test.ts
+++ b/test/gateway-irs.test.ts
@@ -1,0 +1,192 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import { deployFullSuiteFixture } from './fixtures/deploy-full-suite.fixture';
+
+const tokenDetails = (owner: string, name: string, irs: string = ethers.constants.AddressZero, irAgents: string[] = []) => ({
+  owner,
+  name,
+  symbol: name.toUpperCase().slice(0, 4),
+  decimals: 8,
+  irs,
+  ONCHAINID: ethers.constants.AddressZero,
+  irAgents,
+  tokenAgents: [],
+  complianceModules: [],
+  complianceSettings: [],
+});
+
+const emptyClaims = { claimTopics: [], issuers: [], issuerClaims: [] };
+
+async function setup() {
+  const context = await loadFixture(deployFullSuiteFixture);
+  // public deployment enabled: anyone can deploy for themselves
+  const gateway = await ethers.deployContract('TREXGateway', [context.factories.trexFactory.address, true], context.accounts.deployer);
+  await context.factories.trexFactory.transferOwnership(gateway.address);
+  return { context, gateway };
+}
+
+async function irsOfLastDeployment(context: any, owner: string, name: string) {
+  const salt = owner.toLowerCase() + name;
+  const tokenAddr = await context.factories.trexFactory.getToken(salt);
+  const token = await ethers.getContractAt('Token', tokenAddr);
+  const ir = await ethers.getContractAt('IdentityRegistry', await token.identityRegistry());
+  return ir.identityStorage();
+}
+
+describe('TREXGateway - IRS access control', () => {
+  it('registers a freshly deployed IRS with the token owner as IRS owner', async () => {
+    const { context, gateway } = await setup();
+    const alice = context.accounts.aliceWallet;
+
+    const tx = await gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken'), emptyClaims);
+    const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
+
+    await expect(tx).to.emit(gateway, 'IRSRegistered').withArgs(irs, alice.address);
+    expect(await gateway.getIRSOwner(irs)).to.equal(alice.address);
+    expect(await gateway.isIRSUsageAuthorized(irs, alice.address)).to.be.true;
+    expect(await gateway.isIRSUsageAuthorized(irs, context.accounts.bobWallet.address)).to.be.false;
+  });
+
+  it('blocks another token owner from binding to an IRS they do not own (the original issue)', async () => {
+    const { context, gateway } = await setup();
+    const alice = context.accounts.aliceWallet;
+    const bob = context.accounts.bobWallet;
+
+    await gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken'), emptyClaims);
+    const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
+
+    await expect(gateway.connect(bob).deployTREXSuite(tokenDetails(bob.address, 'BobToken', irs, [bob.address]), emptyClaims))
+      .to.be.revertedWithCustomError(gateway, 'IRSUsageNotAuthorized')
+      .withArgs(irs, bob.address);
+  });
+
+  it('lets the IRS owner reuse their own IRS for a second token', async () => {
+    const { context, gateway } = await setup();
+    const alice = context.accounts.aliceWallet;
+
+    await gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken'), emptyClaims);
+    const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
+
+    await expect(gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken2', irs), emptyClaims)).to.not.be.reverted;
+    expect(await irsOfLastDeployment(context, alice.address, 'AliceToken2')).to.equal(irs);
+    // second deployment did not re-register / overwrite the IRS owner
+    expect(await gateway.getIRSOwner(irs)).to.equal(alice.address);
+  });
+
+  it('rejects an unregistered IRS', async () => {
+    const { context, gateway } = await setup();
+    const bob = context.accounts.bobWallet;
+    const legacyIrs = context.suite.identityRegistryStorage.address;
+
+    await expect(gateway.connect(bob).deployTREXSuite(tokenDetails(bob.address, 'BobToken', legacyIrs), emptyClaims))
+      .to.be.revertedWithCustomError(gateway, 'IRSNotRegistered')
+      .withArgs(legacyIrs);
+  });
+
+  describe('authorizeIRSUsage / revokeIRSUsage', () => {
+    it('only the IRS owner can authorize', async () => {
+      const { context, gateway } = await setup();
+      const alice = context.accounts.aliceWallet;
+      const bob = context.accounts.bobWallet;
+      await gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken'), emptyClaims);
+      const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
+
+      await expect(gateway.connect(bob).authorizeIRSUsage(irs, bob.address)).to.be.revertedWithCustomError(gateway, 'OnlyIRSOwnerCall');
+      // gateway owner/admin is not the IRS owner either
+      await expect(gateway.connect(context.accounts.deployer).authorizeIRSUsage(irs, bob.address)).to.be.revertedWithCustomError(
+        gateway,
+        'OnlyIRSOwnerCall',
+      );
+    });
+
+    it('authorized token owner can reuse the IRS, revoked one cannot', async () => {
+      const { context, gateway } = await setup();
+      const alice = context.accounts.aliceWallet;
+      const bob = context.accounts.bobWallet;
+      await gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken'), emptyClaims);
+      const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
+
+      await expect(gateway.connect(alice).authorizeIRSUsage(irs, bob.address)).to.emit(gateway, 'IRSUsageAuthorized').withArgs(irs, bob.address);
+      await expect(gateway.connect(alice).authorizeIRSUsage(irs, bob.address)).to.be.revertedWithCustomError(gateway, 'IRSUsageAlreadyAuthorized');
+      expect(await gateway.isIRSUsageAuthorized(irs, bob.address)).to.be.true;
+
+      await expect(gateway.connect(bob).deployTREXSuite(tokenDetails(bob.address, 'BobToken', irs), emptyClaims)).to.not.be.reverted;
+      expect(await irsOfLastDeployment(context, bob.address, 'BobToken')).to.equal(irs);
+      // sharing does not transfer IRS ownership
+      expect(await gateway.getIRSOwner(irs)).to.equal(alice.address);
+
+      await expect(gateway.connect(alice).revokeIRSUsage(irs, bob.address)).to.emit(gateway, 'IRSUsageRevoked').withArgs(irs, bob.address);
+      await expect(gateway.connect(alice).revokeIRSUsage(irs, bob.address)).to.be.revertedWithCustomError(gateway, 'IRSUsageNotAuthorized');
+      await expect(gateway.connect(bob).deployTREXSuite(tokenDetails(bob.address, 'BobToken2', irs), emptyClaims)).to.be.revertedWithCustomError(
+        gateway,
+        'IRSUsageNotAuthorized',
+      );
+    });
+  });
+
+  describe('transferIRSOwnership', () => {
+    it('moves control of the IRS sharing rules', async () => {
+      const { context, gateway } = await setup();
+      const alice = context.accounts.aliceWallet;
+      const bob = context.accounts.bobWallet;
+      await gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken'), emptyClaims);
+      const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
+
+      await expect(gateway.connect(bob).transferIRSOwnership(irs, bob.address)).to.be.revertedWithCustomError(gateway, 'OnlyIRSOwnerCall');
+      await expect(gateway.connect(alice).transferIRSOwnership(irs, ethers.constants.AddressZero)).to.be.revertedWithCustomError(gateway, 'ZeroAddress');
+      await expect(gateway.connect(alice).transferIRSOwnership(irs, bob.address))
+        .to.emit(gateway, 'IRSOwnershipTransferred')
+        .withArgs(irs, alice.address, bob.address);
+
+      expect(await gateway.getIRSOwner(irs)).to.equal(bob.address);
+      await expect(gateway.connect(alice).authorizeIRSUsage(irs, alice.address)).to.be.revertedWithCustomError(gateway, 'OnlyIRSOwnerCall');
+      await expect(gateway.connect(bob).deployTREXSuite(tokenDetails(bob.address, 'BobToken', irs), emptyClaims)).to.not.be.reverted;
+    });
+  });
+
+  describe('recoverIRSOwnership', () => {
+    it('transfers Ownable ownership of the IRS from the factory to the IRS owner, after which it cannot be reused through the factory', async () => {
+      const { context, gateway } = await setup();
+      const alice = context.accounts.aliceWallet;
+      const bob = context.accounts.bobWallet;
+      await gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken'), emptyClaims);
+      const irs = await irsOfLastDeployment(context, alice.address, 'AliceToken');
+      const irsContract = await ethers.getContractAt('IdentityRegistryStorage', irs);
+      expect(await irsContract.owner()).to.equal(context.factories.trexFactory.address);
+
+      await expect(gateway.connect(bob).recoverIRSOwnership(irs)).to.be.revertedWithCustomError(gateway, 'OnlyIRSOwnerCall');
+      await expect(gateway.connect(alice).recoverIRSOwnership(irs)).to.emit(gateway, 'IRSOwnershipRecovered').withArgs(irs, alice.address);
+      expect(await irsContract.owner()).to.equal(alice.address);
+
+      await expect(gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken2', irs), emptyClaims))
+        .to.be.revertedWithCustomError(gateway, 'IRSNotOwnedByFactory')
+        .withArgs(irs);
+
+      // giving ownership back to the factory re-enables reuse, registration was kept
+      await irsContract.connect(alice).transferOwnership(context.factories.trexFactory.address);
+      await expect(gateway.connect(alice).deployTREXSuite(tokenDetails(alice.address, 'AliceToken2', irs), emptyClaims)).to.not.be.reverted;
+    });
+  });
+
+  describe('registerIRS (legacy IRS onboarding)', () => {
+    it('admin can register a pre-existing IRS owned by the factory', async () => {
+      const { context, gateway } = await setup();
+      const bob = context.accounts.bobWallet;
+      const legacyIrs = context.suite.identityRegistryStorage;
+
+      // not owned by factory yet
+      await expect(gateway.registerIRS(legacyIrs.address, bob.address)).to.be.revertedWithCustomError(gateway, 'IRSNotOwnedByFactory');
+
+      await legacyIrs.connect(context.accounts.deployer).transferOwnership(context.factories.trexFactory.address);
+
+      await expect(gateway.connect(bob).registerIRS(legacyIrs.address, bob.address)).to.be.revertedWithCustomError(gateway, 'OnlyAdminCall');
+      await expect(gateway.registerIRS(legacyIrs.address, bob.address)).to.emit(gateway, 'IRSRegistered').withArgs(legacyIrs.address, bob.address);
+      await expect(gateway.registerIRS(legacyIrs.address, bob.address)).to.be.revertedWithCustomError(gateway, 'IRSAlreadyRegistered');
+
+      await expect(gateway.connect(bob).deployTREXSuite(tokenDetails(bob.address, 'BobToken', legacyIrs.address), emptyClaims)).to.not.be.reverted;
+      expect(await irsOfLastDeployment(context, bob.address, 'BobToken')).to.equal(legacyIrs.address);
+    });
+  });
+});


### PR DESCRIPTION
### Problem

`TREXGateway.deployTREXSuite` lets a deployer pass any address as `TokenDetails.irs`. The Gateway forwarded it to the Factory without checking who owns that IRS or who deployed it. Because the IRS is owned by the Factory (so the Factory can `bindIdentityRegistry` new IRs to it), any deployer could reference someone else's IRS in their own deployment and get a fresh Identity Registry bound to it. In practice that means a third party could attach themselves to another issuer's identity storage. There was no notion of "who owns this IRS" at the Gateway level, so there was nothing to check against.

### Fix

The Gateway now tracks an owner per IRS and gates reuse on it. By default an IRS can only be reused by the owner of the token it was deployed for. The owner can explicitly share it with other token owners, transfer that control, and pull the IRS contract ownership back from the Factory when they want to manage it directly.

Nothing changes for the common path: deploying a suite with `irs = address(0)` still deploys a new IRS, and it now gets registered to the token owner automatically.

### Changes

**State**
- `_irsOwner`: IRS address → registered owner (controls reuse rules on the Gateway).
- `_irsAuthorizedUsers`: IRS address → token owner → allowed to reuse.

**`deployTREXSuite` logic**
- New IRS (`irs == address(0)`): after the Factory deploys, the resolved IRS is registered to `TokenDetails.owner` (`IRSRegistered`).
- Existing IRS (`irs != address(0)`): the call reverts unless the IRS is registered, `TokenDetails.owner` is authorized (owner or explicitly allowed), and the Factory still owns the IRS contract so it can actually bind the new IR.

**New functions**
- `registerIRS(address irs, address irsOwner)` — admin-only. Onboards a pre-existing IRS (deployed before this change or outside the Gateway) so it can be reused under the same rules. Requires the Factory to own the IRS.
- `authorizeIRSUsage(address irs, address tokenOwner)` / `revokeIRSUsage(...)` — IRS owner only. Grants or removes another token owner's right to reuse the IRS. Revoking only blocks future deployments; IRs already bound stay bound.
- `transferIRSOwnership(address irs, address newOwner)` — IRS owner only. Moves the Gateway-level control. Does not touch the IRS contract's `Ownable` owner (still the Factory).
- `recoverIRSOwnership(address irs)` — IRS owner only. Calls the Factory's `recoverContractOwnership` to hand the IRS's `Ownable` ownership to the caller. After this the Factory can no longer bind to it, so deployments referencing it revert with `IRSNotOwnedByFactory` until ownership is returned to the Factory. The Gateway registration is kept, so reuse resumes automatically once ownership goes back.
- `getIRSOwner(address irs)` / `isIRSUsageAuthorized(address irs, address tokenOwner)` — views.

**Events**: `IRSRegistered`, `IRSOwnershipTransferred`, `IRSUsageAuthorized`, `IRSUsageRevoked`, `IRSOwnershipRecovered`.

**Errors**: `IRSNotRegistered`, `IRSAlreadyRegistered`, `IRSNotOwnedByFactory`, `OnlyIRSOwnerCall`, `IRSUsageNotAuthorized`, `IRSUsageAlreadyAuthorized`.

### Design notes

- Two ownership concepts stay separate on purpose: the IRS contract's `Ownable` owner (the Factory, needed for binding) vs. the Gateway's registered IRS owner (who controls sharing). `transferIRSOwnership` moves the second, `recoverIRSOwnership` moves the first.
- Authorization is keyed on `TokenDetails.owner`, not `msg.sender`, so it lines up with who the deployed suite actually belongs to and works whether the deployer is the owner or an approved deployer acting for them.
- The `Ownable(irs).owner() == _factory` check makes the failure mode explicit instead of letting the Factory call revert opaquely.

### Backwards compatibility

The default deploy flow (`irs = address(0)`) is unchanged aside from the new auto-registration. Existing IRS contracts already in use won't be registered, so reuse through the Gateway requires a one-time `registerIRS` by an admin (which also requires the Factory to own the IRS). This is additive: no signatures of existing functions changed.

### Tests

Added `test/gateway-irs.test.ts` covering: auto-registration on new deployment, the original cross-owner binding attempt now reverting, owner reuse, unregistered IRS rejection, authorize/revoke, ownership transfer, and the recover/return-to-Factory round trip. Full gateway suite passes (72 tests: existing 63 + 9 new).

### Files
- `contracts/factory/TREXGateway.sol`
- `contracts/factory/ITREXGateway.sol`
- `test/gateway-irs.test.ts`
